### PR TITLE
added check to ignore input[type=file]

### DIFF
--- a/vendor/js2form.js
+++ b/vendor/js2form.js
@@ -185,6 +185,9 @@
 					if (!result[nameNormalized]) result[nameNormalized] = [];
 					result[nameNormalized].push(currNode);
 				}
+				else if (/INPUT/i.test(currNode.nodeName) && /FILE/i.test(currNode.type)) {
+					return false;
+				}
 				else
 				{
 					if (shouldClean)


### PR DESCRIPTION
Not sure if I should make the pull request here or further upstream.

But added a small quick check to ignore input[type=file] for now, as js2form, when setting values, would overwrite the values set for input[type=file].
