### PR TITLE
Removed commas at the end of each way-repeat entry

### DIFF
--- a/way.js
+++ b/way.js
@@ -517,7 +517,7 @@
 
 			}
 
-			w.dom(wrapper).html(items);
+			w.dom(wrapper).html(items.join(" "));
 			self.registerBindings();
 			self.updateBindings();
 


### PR DESCRIPTION
The commas at the end of each way-repeat entry was a result of the innerHTML property being set as an array on an element.
If commas are desired they should be added to the repeated template.

This resolves #24
