### PR TITLE
Check for module object

### DIFF
--- a/way.js
+++ b/way.js
@@ -2,7 +2,7 @@
 
 	if (typeof define === "function" && define.amd) {
 		define(factory);
-	} else if (typeof exports === "object") {
+	} else if (typeof module === "object") {
 		module.exports = factory();
 	} else {
 		root.way = factory();


### PR DESCRIPTION
Although module is usually defined whenever exports is defined, I
believe it is cleaner and makes more sense to check for the
existence of the module object before setting a property on it
(as opposed to checking for the exports object).

A theoretical scenario where this might become a problem is when
the user sets window.exports and define is not a function.

Although this is a very theoretical example, this probably makes
more sense.