### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1"
+  },
+  "spm": {
+    "main": "way.js"
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/way.js

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of way.js in spmjs, I can add it for your account after signing in http://spmjs.io.
